### PR TITLE
logger: open debug log in append mode

### DIFF
--- a/github/logger.py
+++ b/github/logger.py
@@ -12,7 +12,7 @@ logger.setLevel(DEBUG)
 # create console handler
 console_debug_handler = StreamHandler(stream=stdout)
 console_debug_handler.setLevel(DEBUG)
-file_debug_handler = FileHandler(f'{dirname(github.__file__)}/../logs/debug.log')
+file_debug_handler = FileHandler(filename='{dirname(github.__file__)}/../logs/debug.log', mode='a')
 file_debug_handler.setLevel(DEBUG)
 
 


### PR DESCRIPTION
Open debug log in append mode. If debug.log does not exist, an exception was thrown.

Signed-off-by: skjera